### PR TITLE
Fix DateTime update comparison

### DIFF
--- a/src/forms/datetime.js
+++ b/src/forms/datetime.js
@@ -45,13 +45,11 @@ class Datetime extends React.Component {
         this.setState(prevState => {
           let updates = {}
           // check if the date value is different
-          let prevFallbackDate = this.fallbackDate(prevState.date)
-          if (split.date !== prevFallbackDate || prevProps.value === null) {
+          if (split.date !== prevState.date) {
             updates.date = split.date
           }
           // check if the time value is different
-          let prevFallbackTime = this.fallbackTime(prevState.time)
-          if (split.time !== prevFallbackTime || prevProps.value === null) {
+          if (split.time !== prevState.time) {
             updates.time = split.time
           }
           return updates


### PR DESCRIPTION
**Description of Issue**
If I update the `value` through props, then `this.fallbackDate(prevState.date)` generates the same value as `split.date` AND my `prevProps.value` is `undefined` so my time gets updated but not my date.

See example here where the time is updated but not the date when passing the current time in through the value prop.  (╯°□°）╯︵ ┻━┻)
![screenshot from 2018-11-22 16-26-54](https://user-images.githubusercontent.com/19770543/48883338-78321d00-ee73-11e8-9910-0052d0c7a035.png)

**Fix**
Idk, but this seems logical. Comparing the new props to the current state and updating if the new props is different from the current state.
